### PR TITLE
Feature/remove ignored certificate

### DIFF
--- a/GatewayApiClient.nuspec
+++ b/GatewayApiClient.nuspec
@@ -2,14 +2,14 @@
 <package >
   <metadata>
     <id>MundiPagg.Gateway.Client</id>
-    <version>1.3.2</version>
+    <version>2.0.0</version>
     <authors>MundiPagg</authors>
     <owners>MundiPagg</owners>
     <projectUrl>https://github.com/mundipagg/mundipagg-one-dotnet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MundiPagg Gateway Client</description>
-    <releaseNotes>Adds Token creation functionality</releaseNotes>
-    <copyright>MundiPagg 2016</copyright>
+    <releaseNotes>Remove code that ignores certification</releaseNotes>
+    <copyright>MundiPagg 2017</copyright>
     <tags>MundiPagg Credit Card Payment Boleto Gateway Transaction</tags>
   </metadata>
 </package>

--- a/ResourceClients/BaseResource.cs
+++ b/ResourceClients/BaseResource.cs
@@ -26,7 +26,6 @@ namespace GatewayApiClient.ResourceClients {
             }
 
             this.HttpUtility = new HttpUtility();
-            System.Net.ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
 
             this.MerchantKey = merchantKey;
             if (hostUri != null) {


### PR DESCRIPTION
O que faz ? 
Remove código que estava ignorando o certificado.

Por que ? 
Porque o domínio de regra de certificado, deve ficar do lado do cliente.

Como ? 
Removendo a linha que ignora a validação de certificado.